### PR TITLE
fix(config): update shared_workflow_version to post-squash SHA

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -18,4 +18,4 @@ repos:
       - merge
       - closeout
     # Pin to a release tag or SHA — never a mutable branch (see discussion #3 §2)
-    shared_workflow_version: c1ca348dfd0973edb46136a9865d2805f903c47a
+    shared_workflow_version: 08cf90ef668d27986151c19194f7632e210d1820


### PR DESCRIPTION
## Summary

- Updates `config/repos.yml` `shared_workflow_version` from stale pre-squash SHA (`c1ca348`) to the correct post-merge SHA (`08cf90ef668d27986151c19194f7632e210d1820`)

## Context

PR #4 merged as a squash commit (`08cf90e`) on `main`, but `repos.yml` still referenced a commit from the development branch that no longer exists on `main`.

Closes #12

## Verification

- `scripts/validate-config.py` passes ✓
- SHA `08cf90e` confirmed present on `main` via `git rev-parse`

## Test plan

- [x] `scripts/validate-config.py` passes
- [x] Single-line change, no functional impact beyond correcting the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)